### PR TITLE
Remove 'istextorbinary' dependency

### DIFF
--- a/packages/zombi/package.json
+++ b/packages/zombi/package.json
@@ -19,17 +19,18 @@
     "precommit": "lint-staged"
   },
   "dependencies": {
+    "binaryextensions": "^4.15.0",
     "chalk": "^2.4.1",
     "ejs": "^2.5.7",
     "enquirer": "^2.3.6",
     "execa": "^4.0.3",
     "fs-extra": "^5.0.0",
-    "istextorbinary": "~5.7.0",
     "lodash": "^4.17.19",
     "ora": "^5.1.0",
     "pretty-time": "~1.1.0",
     "react-ssr-prepass": "^1.2.1",
-    "semaphore-async-await": "^1.5.1"
+    "semaphore-async-await": "^1.5.1",
+    "textextensions": "^5.12.0"
   },
   "devDependencies": {
     "@types/ejs": "^3.0.5",

--- a/packages/zombi/src/fs.ts
+++ b/packages/zombi/src/fs.ts
@@ -1,9 +1,9 @@
 import fsExtra from 'fs-extra';
 import { renderFile } from 'ejs';
 import { isAbsolute, join, resolve as pathResolve } from 'path';
-import { isBinary } from 'istextorbinary';
 import chalk from 'chalk';
 import { isNil, isEmpty } from 'lodash';
+import { isBinary } from './utils/is-binary';
 import { createPromise } from './utils/create-promise';
 import { ZombiContext } from './components/zombi';
 import { PromptWrapper } from './types';

--- a/packages/zombi/src/utils/is-binary.ts
+++ b/packages/zombi/src/utils/is-binary.ts
@@ -1,0 +1,156 @@
+/**
+ * The utilities in this file are based on the NPM module `istextorbinary`.
+ *
+ * The implementation is copied here to reduce dependency overhead
+ * and improve compatibliity with NodeJS compilers like `@vercel/ncc`.
+ *
+ * @see the `LICENSE` file at the root of this source tree:
+ *   https://github.com/bevry/istextorbinary/blob/master/source/index.ts
+ */
+
+import type Buffer from 'buffer';
+import * as pathUtil from 'path';
+import textExtensions from 'textextensions';
+import binaryExtensions from 'binaryextensions';
+
+/**
+ * Determine if the filename and/or buffer is text.
+ *
+ * Determined by extension checks first (if filename is available), otherwise if
+ * the extension is unrecognized or no filename is provided, will perform a
+ * slower buffer encoding detection.
+ *
+ * Extension checks are quicker.
+ * Encoding checks cannot guarantee accuracy for chars between utf8 and utf16.
+ *
+ * The extension checks are performed using the following resources:
+ *   - https://github.com/bevry/textextensions
+ *   - https://github.com/bevry/binaryextensions
+ *
+ * @param filename The filename for the file/buffer if available
+ * @param buffer The buffer for the file if available
+ * @returns Will be `null` if neither `filename` nor `buffer` were provided. Otherwise will be a `boolean` value with the detection result.
+ */
+function isText(filename?: string | null, buffer?: Buffer | null): boolean | null {
+  // Test extensions
+  if (filename) {
+    // Extract filename
+    const parts = pathUtil.basename(filename).split('.').reverse();
+
+    // Cycle extensions
+    for (const extension of parts) {
+      if (textExtensions.includes(extension)) {
+        return true;
+      }
+      if (binaryExtensions.includes(extension)) {
+        return false;
+      }
+    }
+  }
+
+  // Fallback to encoding if extension check was not enough
+  if (buffer) {
+    return getEncoding(buffer) === 'utf8';
+  }
+
+  // No buffer was provided
+  return null;
+}
+
+interface EncodingOpts {
+  /**
+   * Defaults to 24.
+   */
+  chunkLength?: number;
+
+  /**
+   * If not provided, will check the start, beginning, and end.
+   */
+  chunkBegin?: number;
+}
+
+/**
+ * Get the encoding of a buffer.
+ *
+ * Checks the start, middle, and end of the buffer for characters that are
+ * unrecognized within UTF8 encoding. History has shown that inspection at all
+ * three locations is necessary.
+ *
+ * @returns Will be `null` if `buffer` was not provided. Otherwise will be either `'utf8'` or `'binary'`.
+ */
+function getEncoding(buffer: Buffer | null, opts?: EncodingOpts): 'utf8' | 'binary' | null {
+  // Check
+  if (!buffer) return null;
+
+  // Prepare
+  const textEncoding = 'utf8';
+  const binaryEncoding = 'binary';
+  const chunkLength = opts?.chunkLength ?? 24;
+  let chunkBegin = opts?.chunkBegin ?? 0;
+
+  // Discover
+  if (opts?.chunkBegin == null) {
+    // Start
+    let encoding = getEncoding(buffer, { chunkLength, chunkBegin });
+    if (encoding === textEncoding) {
+      // Middle
+      chunkBegin = Math.max(0, Math.floor(buffer.length / 2) - chunkLength);
+      encoding = getEncoding(buffer, {
+        chunkLength,
+        chunkBegin,
+      });
+      if (encoding === textEncoding) {
+        // End
+        chunkBegin = Math.max(0, buffer.length - chunkLength);
+        encoding = getEncoding(buffer, {
+          chunkLength,
+          chunkBegin,
+        });
+      }
+    }
+
+    // Return
+    return encoding;
+  }
+  // Extract
+  const chunkEnd = Math.min(buffer.length, chunkBegin + chunkLength);
+  const contentChunkUTF8 = buffer.toString(textEncoding, chunkBegin, chunkEnd);
+
+  // Detect encoding
+  for (let i = 0; i < contentChunkUTF8.length; ++i) {
+    const charCode = contentChunkUTF8.charCodeAt(i);
+    if (charCode === 65533 || charCode <= 8) {
+      // 8 and below are control characters (e.g. backspace, null, eof, etc.)
+      // 65533 is the unknown character
+      // console.log(charCode, contentChunkUTF8[i])
+      return binaryEncoding;
+    }
+  }
+
+  // Return
+  return textEncoding;
+}
+
+/**
+ * Determine if the filename and/or buffer is binary.
+ *
+ * Determined by extension checks first (if filename is available), otherwise if
+ * the extension is unrecognized or no filename is provided, will perform a
+ * slower buffer encoding detection.
+ *
+ * Extension checks are quicker.
+ * Encoding checks cannot guarantee accuracy for chars between utf8 and utf16.
+ *
+ * The extension checks are performed using the following resources:
+ *   - https://github.com/bevry/textextensions
+ *   - https://github.com/bevry/binaryextensions
+ *
+ * @param filename The filename for the file/buffer if available
+ * @param buffer The buffer for the file if available
+ * @returns Will be `null` if neither `filename` nor `buffer` were provided. Otherwise will be a `boolean` value with the detection result.
+ */
+export function isBinary(filename?: string | null, buffer?: Buffer | null) {
+  const text = isText(filename, buffer);
+  if (text == null) return null;
+  return !text;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1880,10 +1880,10 @@ before-after-hook@^2.0.0, before-after-hook@^2.1.0:
   resolved "https://registry.yarnpkg.com/before-after-hook/-/before-after-hook-2.1.0.tgz#b6c03487f44e24200dd30ca5e6a1979c5d2fb635"
   integrity sha512-IWIbu7pMqyw3EAJHzzHbWa85b6oud/yfKYg5rqB5hNE8CeMi3nX+2C2sj0HswfblST86hpVEOAb9x34NZd6P7A==
 
-binaryextensions@4.7.0:
-  version "4.7.0"
-  resolved "https://registry.yarnpkg.com/binaryextensions/-/binaryextensions-4.7.0.tgz#6ef6f69f6b885af9e6d1fd2a621195d0b7c686a2"
-  integrity sha512-yXyoXbBJj9i9FAUhAiOMcRsyr0HgSVzgeW8dOGIMQQ4m72R4Y03t+REqfPfsobWTN7y52hhdDXMwK0F3kHf/LA==
+binaryextensions@^4.15.0:
+  version "4.15.0"
+  resolved "https://registry.yarnpkg.com/binaryextensions/-/binaryextensions-4.15.0.tgz#c63a502e0078ff1b0e9b00a9f74d3c2b0f8bd32e"
+  integrity sha512-MkUl3szxXolQ2scI1PM14WOT951KnaTNJ0eMKg7WzOI4kvSxyNo/Cygx4LOBNhwyINhAuSQpJW1rYD9aBSxGaw==
 
 bluebird@^3.5.1, bluebird@^3.5.3, bluebird@^3.5.5:
   version "3.7.2"
@@ -2811,14 +2811,6 @@ ecc-jsbn@~0.1.1:
     jsbn "~0.1.0"
     safer-buffer "^2.1.0"
 
-editions@^3.10.0:
-  version "3.16.0"
-  resolved "https://registry.yarnpkg.com/editions/-/editions-3.16.0.tgz#63ae6aa5d7921403dcc678aca28bfa9bc0212802"
-  integrity sha512-DUuN1+t7sMFVR4+kCbYNVNAg43It402JqEyGcgdqG/PlmReBUoULfJSP7nXVMzhyRexQbl3XEmLQsDdmS7nRqg==
-  dependencies:
-    errlop "^3.14.0"
-    semver "6.3.0"
-
 ejs@^2.5.7:
   version "2.7.4"
   resolved "https://registry.yarnpkg.com/ejs/-/ejs-2.7.4.tgz#48661287573dcc53e366c7a1ae52c3a120eec9ba"
@@ -2896,11 +2888,6 @@ err-code@^1.0.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/err-code/-/err-code-1.1.2.tgz#06e0116d3028f6aef4806849eb0ea6a748ae6960"
   integrity sha1-BuARbTAo9q70gGhJ6w6mp0iuaWA=
-
-errlop@^3.14.0:
-  version "3.17.0"
-  resolved "https://registry.yarnpkg.com/errlop/-/errlop-3.17.0.tgz#74f3a576447c5023266faac16a21e081f3bd989a"
-  integrity sha512-TDlb+YMx08OiaLq1g7Hu0nDca/oLo+LpMEgEI2lybBKE1rB8qsqFgXzEbnn1LU6NfDCfIdVcl3073aO3ZLTYNg==
 
 error-ex@^1.2.0, error-ex@^1.3.1:
   version "1.3.2"
@@ -4461,15 +4448,6 @@ isstream@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
   integrity sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=
-
-istextorbinary@~5.7.0:
-  version "5.7.0"
-  resolved "https://registry.yarnpkg.com/istextorbinary/-/istextorbinary-5.7.0.tgz#24ac39cfe9807d481e6d867f41ea3fde91ee99ed"
-  integrity sha512-6m7oXf0/SriI70K4TiGb1lWlykyHbKipY0PP5rBvCNrtKew5NiZfz/+1KoZJQ+EEvEdHJjmtmtBl1CxP2FIrbg==
-  dependencies:
-    binaryextensions "4.7.0"
-    editions "^3.10.0"
-    textextensions "5.6.0"
 
 java-properties@^1.0.0:
   version "1.0.2"
@@ -6593,7 +6571,7 @@ semver-compare@^1.0.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
 
-semver@6.3.0, semver@^6.0.0, semver@^6.2.0:
+semver@^6.0.0, semver@^6.2.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
@@ -7222,10 +7200,10 @@ text-table@^0.2.0:
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
   integrity sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=
 
-textextensions@5.6.0:
-  version "5.6.0"
-  resolved "https://registry.yarnpkg.com/textextensions/-/textextensions-5.6.0.tgz#b8ebff97847941529d30cca7b8fe276b00d38445"
-  integrity sha512-NF+IgMk/8Apvt+j9e70zz77TjkdsJrz8A5qfUB4vFNezVy/so8Q+B/P/79FAn2rsKwn49U+TegDRjLBkwrpkbQ==
+textextensions@^5.12.0:
+  version "5.12.0"
+  resolved "https://registry.yarnpkg.com/textextensions/-/textextensions-5.12.0.tgz#b908120b5c1bd4bb9eba41423d75b176011ab68a"
+  integrity sha512-IYogUDaP65IXboCiPPC0jTLLBzYlhhw2Y4b0a2trPgbHNGGGEfuHE6tds+yDcCf4mpNDaGISFzwSSezcXt+d6w==
 
 thenify-all@^1.0.0:
   version "1.6.0"


### PR DESCRIPTION
Copies the source code of `istextorbinary` so that the underlying dependency can be removed. This is to reduce dependency overhead and enable better support for `@vercel/ncc` compilation.

### ⚠️ Don't forget to add a [semver](https://semver.org/) label!

- `patch`: Bug Fix?
- `minor`: New Feature?
- `major`: Breaking Change?
- `skip-release`: It's unnecessary to publish this change.
