### PR TITLE
Feature: Symlinks

### DIFF
--- a/packages/zombi/src/components/effect.tsx
+++ b/packages/zombi/src/components/effect.tsx
@@ -5,7 +5,7 @@ import { ZombiContext } from './zombi';
 export interface Effect<T extends EjsData = EjsData> {
   from: string;
   to: string;
-  options: ZombiContext<T>;
+  options: ZombiContext<T> & { symlink: boolean };
 }
 
 /**


### PR DESCRIPTION
You can now use `<Template.Symlink />` to create symlinks between template files and destination files.